### PR TITLE
GoPlant-702586-gradle-v7-updates

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -1,12 +1,5 @@
-repositories{
-    jcenter()
-    flatDir{
-        dirs 'libs'
-    }
-}
-
 dependencies {
-    compile(name:'barcodescanner-release-2.1.5', ext:'aar')
+    implementation files('libs/barcodescanner-release-2.1.5.aar')
 }
 
 android {


### PR DESCRIPTION
fix: use configuration 'implementation' to prevent build error(s) with AGP 7+